### PR TITLE
Optimize function

### DIFF
--- a/CNC.py
+++ b/CNC.py
@@ -4350,6 +4350,8 @@ class GCode:
 				y2 = block.sy
 				dx = x1-x2
 				dy = y1-y2
+				dx/=CNC.feedmax_x
+				dy/=CNC.feedmax_y
 				matrix[i][j] = sqrt(dx*dx + dy*dy)
 		#from pprint import pprint
 		#pprint(matrix)


### PR DESCRIPTION
It is corrected.
In case the speed of CNC.feedmax_x CNC.feedmax_y different optimize correctly works!